### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/components/org.wso2.carbon.identity.authenticator.mutualssl/src/main/java/org/wso2/carbon/identity/authenticator/mutualssl/MutualSSLAuthenticator.java
+++ b/components/org.wso2.carbon.identity.authenticator.mutualssl/src/main/java/org/wso2/carbon/identity/authenticator/mutualssl/MutualSSLAuthenticator.java
@@ -80,6 +80,8 @@ public class MutualSSLAuthenticator implements CarbonServerAuthenticator {
      */
     private static final String CHARACTER_ENCODING = "UTF-8";
 
+    private static final String ENABLE_SHA256_CERTIFICATE_THUMBPRINT = "EnableSHA256";
+
     /**
      * Logger for the class
      */
@@ -89,6 +91,7 @@ public class MutualSSLAuthenticator implements CarbonServerAuthenticator {
     private static String[] whiteList;
     private static boolean whiteListEnabled = false;
     private static boolean authenticatorInitialized = false;
+    private static boolean enableSHA256CertificateThumbprint = true;
 
 
     /**
@@ -140,6 +143,11 @@ public class MutualSSLAuthenticator implements CarbonServerAuthenticator {
                     }
                 }
                 authenticatorInitialized = true;
+
+                if (configParameters.containsKey(ENABLE_SHA256_CERTIFICATE_THUMBPRINT)) {
+                    enableSHA256CertificateThumbprint = Boolean.parseBoolean(
+                            configParameters.get(ENABLE_SHA256_CERTIFICATE_THUMBPRINT));
+                }
             }
 
         } else {
@@ -391,7 +399,12 @@ public class MutualSSLAuthenticator implements CarbonServerAuthenticator {
      * @throws CertificateEncodingException
      */
     private String getThumbPrint(X509Certificate cert) throws NoSuchAlgorithmException, CertificateEncodingException {
-        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        MessageDigest md;
+        if (enableSHA256CertificateThumbprint) {
+            md = MessageDigest.getInstance("SHA-256");
+        } else {
+            md = MessageDigest.getInstance("SHA-1");
+        }
         byte[] certEncoded = cert.getEncoded();
         md.update(certEncoded);
         return hexify(md.digest());


### PR DESCRIPTION
## Purpose

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.
- Certificate thumbprint will be generated using SHA256 algorithm.

## Migration impact

To revert the behaviour to use SHA1 algorithm, please add the below config to deployment.toml
```
[admin_console.authenticator.mutual_ssl_authenticator.config]
enableSHA256 = false
```

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

